### PR TITLE
Dockerizing App for Google Cloud Run

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.git
+*.log

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 node_modules
 .git
 *.log
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:18-alpine
+
+# Set this new directory as our working directory for subsequent instructions
+WORKDIR /dockerapp
+
+# Copy relevant files in the current directory into the container
+COPY public/ /dockerapp/public
+COPY src/ /dockerapp/src
+COPY package.json /dockerapp/package.json
+
+# Install all the node modules required by the React app
+RUN npm install
+
+# Expose the port on which the React app will run
+EXPOSE 3000
+
+# Build the React app
+CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# from researching, it appears that multi-stage builds are required to get react apps 
+# from researching, it appears that multi-stage builds are required for react apps 
 # Stage 1: Build the React app
 FROM node:18 AS builder
 
@@ -24,9 +24,6 @@ FROM nginx:alpine
 
 # Copy built files from the previous stage to nginx public folder
 COPY --from=builder /dockerapp/build /usr/share/nginx/html
-
-# Expose port 300 (be sure that this is the port Cloud Run expects)
-#EXPOSE 3000
 
 # Expose port 80 - this is nginx default
 EXPOSE 80

--- a/deploymentnotes.txt
+++ b/deploymentnotes.txt
@@ -1,0 +1,22 @@
+Brendan - Nov 9
+- trying to keep some notes here on docker image deployment to google cloud run
+- things I have changed that I think are useful:
+1. The CMD in Dockerfile should be in JSON array format (this is more reliable): CMD ["npm", "start"]
+2. The "--reload" flag on our uvicorn server should NOT be used for deployment (just local dev)
+3. The desired port (3000) should be "exposed" in the Dockerfile: EXPOSE 3000 
+4. ***MOST IMPORTANT - if using a Mac, when you go to create an image to deploy to Google Cloud, you must build with the "--platform linux/amd64" flag*****
+
+
+How to: build docker image, push to docker hub, deploy via Google Cloud Run UI
+1. Build image: docker build --platform linux/amd64 -t jbh14/quibble-frontend:1.0.1 .
+- (can omit the repo name, "jbh14/quibble-frontend" in this case, if you want to build locally)
+- "--platform linux/amd64" is CRUCIAL for Mac users to build images that can be deployed to Google Cloud Run, but should not be used for local testing
+2. If wanted to deploy to Google Cloud Run, Login to docker if needed: docker login
+3. Push image to docker hub: docker push jbh14/quibble-frontend:1.0.1
+4. Create Cloud Run deployment via UI - list docker hub image URL, allow unauthenticated invocations, set port to 3000
+
+How to: build and test locally:
+1. Build image: docker build -t quibblefrontend-image1 .
+2. Run image locally on port 3000 - no bash script here, but should need one (I don't think the dockerimage used here has a bash script), but the docker-compose.yml file can be used to run the image locally and should take care of "npm start" needed
+3. Alternative apporach - "compose up" (uses compose.yml file to build image and run containter): docker-compose up --build
+- "--build" flag is to rebuild the image if it already exists

--- a/deploymentnotes.txt
+++ b/deploymentnotes.txt
@@ -17,6 +17,8 @@ How to: build docker image, push to docker hub, deploy via Google Cloud Run UI
 
 How to: build and test locally:
 1. Build image: docker build -t quibblefrontend-image1 .
-2. Run image locally on port 3000 - no bash script here, but should need one (I don't think the dockerimage used here has a bash script), but the docker-compose.yml file can be used to run the image locally and should take care of "npm start" needed
+2. Run image locally on port 3000: docker run -p 3000:80 quibblefrontend-image1
+ - nginx wants to use port 80 by default, so "-p 3000:80" is used to map port 3000 on your local machine to port 80 in the container, which is where nginx serves the app
+ - no bash script here, but should not need one (I don't think the dockerimage used here has a bash script), but the docker-compose.yml file can be used to run the image locally and should take care of "npm start" needed
 3. Alternative apporach - "compose up" (uses compose.yml file to build image and run containter): docker-compose up --build
 - "--build" flag is to rebuild the image if it already exists

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+
+services:
+  web:
+    build: .
+    command: sh -c "npm start" 
+    ports:
+      - 3000:3000

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -4,8 +4,8 @@ import ReactMarkdown from 'react-markdown';
 import { Header } from '../components/Header';
 
 const HomePage = () => {
-  // reads URL from .env - be sure to list 'REACT_APP_BACKEND_URL=http://localhost:8000' there if wanting to test fetching from locally running backend app
-  const FETCH_URL = process.env.REACT_APP_BACKEND_URL || 'https://quibble-backend-64265842032.us-central1.run.app';
+  // reads URL from .env (set REACT_APP_BACKEND_URL there) or defaults to localhost for local testing if nothing found there
+  const FETCH_URL = process.env.REACT_APP_BACKEND_URL || 'http://localhost:8000';
 
   const [urls, setUrls] = useState({
     url1: '',

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -4,8 +4,9 @@ import ReactMarkdown from 'react-markdown';
 import { Header } from '../components/Header';
 
 const HomePage = () => {
-  const FETCH_URL = 'https://quibble-backend-64265842032.us-central1.run.app/'; //'http://localhost:8000';
-  
+  // reads URL from .env - be sure to list 'REACT_APP_BACKEND_URL=http://localhost:8000' there if wanting to test fetching from locally running backend app
+  const FETCH_URL = process.env.REACT_APP_BACKEND_URL || 'https://quibble-backend-64265842032.us-central1.run.app';
+
   const [urls, setUrls] = useState({
     url1: '',
     url2: ''
@@ -84,7 +85,7 @@ const HomePage = () => {
       }
     } catch (error) {
       console.error('Error:', error);
-      setError('Failed to compare products. Please try again.');
+      setError(error); 
       setComparison('');
     }
   };

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -4,7 +4,7 @@ import ReactMarkdown from 'react-markdown';
 import { Header } from '../components/Header';
 
 const HomePage = () => {
-  const FETCH_URL = 'http://localhost:8000';
+  const FETCH_URL = 'https://quibble-backend-64265842032.us-central1.run.app/'; //'http://localhost:8000';
   
   const [urls, setUrls] = useState({
     url1: '',


### PR DESCRIPTION
- Dockerfile to build image for deployment to Google Cloud Run
- Small update to HomePage.js to allow reading in a "fetch URL" from local .env (this is gitignored) if wanted to test with locally running backend, or otherwise default to our deployed backend URL.  If preferred, could also attempt to read backend URL from .env as well.