### PR TITLE
Improve Comparison Title Handling, Fix Sidebar Display and Fix Restart Comparison 

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+REACT_APP_BACKEND_URL=https://quibble-backend-64265842032.us-central1.run.app

--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-REACT_APP_BACKEND_URL=https://quibble-backend-64265842032.us-central1.run.app

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.env
 
 npm-debug.log*
 yarn-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -13,11 +13,10 @@
 
 # misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+
+# Ignore environment files
 .env
+.env.*
 
 npm-debug.log*
 yarn-debug.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# from researching, it appears that multi-stage builds are required for react apps 
+# Stage 1: Build the React app
+FROM node:18 AS builder
+
+# Set the working directory
+WORKDIR /dockerapp
+
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application code - note that .dockerignore applies here (only things not ignored are considered)
+COPY . .
+#COPY public/ /dockerapp/public
+#COPY src/ /dockerapp/src
+
+# Build the React app
+RUN npm run build
+
+# Stage 2: Serve the app with a lightweight server
+FROM nginx:alpine
+
+# Copy built files from the previous stage to nginx public folder
+COPY --from=builder /dockerapp/build /usr/share/nginx/html
+
+# Expose port 80 - this is nginx default
+EXPOSE 80
+
+# Start nginx server
+CMD ["nginx", "-g", "daemon off;"]

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-dom": "^18.3.1",
     "react-markdown": "^9.0.1",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "@ramonak/react-progress-bar": "5.3.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -48,7 +48,7 @@ function App() {
         <ComparisonHistorySidebar 
           history={history} 
           onDelete={deleteComparison} 
-          onSelect={setSelectedComparison}
+          onSelect={(data) => setSelectedComparison(data)}
         />
       </div>
     </MantineProvider>

--- a/src/App.js
+++ b/src/App.js
@@ -1,58 +1,20 @@
 import './App.css';
 import '@mantine/core/styles.css';
 import { Header } from './pages/Header';
-import HomePage from './pages/HomePage';
-import ComparisonHistorySidebar from './components/ComparisonHistorySidebar';
+import MainContainer from './pages/MainContainer';
 import { MantineProvider } from '@mantine/core';
-import { useState, useEffect } from 'react';
 
 function App() {
-  // State for managing comparison history
-  const [history, setHistory] = useState([]);
-  const [selectedComparison, setSelectedComparison] = useState('');
-
-  useEffect(() => {
-    // Load history from localStorage on mount
-    const savedComparisons = JSON.parse(localStorage.getItem('comparisonHistory')) || [];
-    setHistory(savedComparisons);
-  }, []);
-
-  // Function to save a comparison to history
-  const saveComparison = (comparisonData) => {
-    const updatedHistory = [...history, comparisonData];
-    setHistory(updatedHistory);
-    localStorage.setItem('comparisonHistory', JSON.stringify(updatedHistory));
-  };
-
-  // Function to delete a comparison from history
-  const deleteComparison = (index) => {
-    const updatedHistory = history.filter((_, idx) => idx !== index);
-    setHistory(updatedHistory);
-    localStorage.setItem('comparisonHistory', JSON.stringify(updatedHistory));
-  };
-
   return (
     <MantineProvider theme={{ fontFamily: 'Roboto, sans-serif' }}>
       <div className="app-layout" style={{ display: 'flex', height: '100vh' }}>
         {/* Main Content Area */}
         <div className="main-content" style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
           <Header />
-          <HomePage 
-            saveComparison={saveComparison} 
-            setSelectedComparison={setSelectedComparison}
-            selectedComparison={selectedComparison}
-          />
+          <MainContainer />
         </div>
-
-        {/* Sidebar for Comparison History */}
-        <ComparisonHistorySidebar 
-          history={history} 
-          onDelete={deleteComparison} 
-          onSelect={(data) => setSelectedComparison(data)}
-        />
       </div>
     </MantineProvider>
   );
 }
-
 export default App;

--- a/src/components/ComparisonHistorySidebar.js
+++ b/src/components/ComparisonHistorySidebar.js
@@ -10,14 +10,14 @@ const ComparisonHistorySidebar = ({ history, onDelete, onSelect }) => {
           <li key={index} style={{ marginBottom: '10px' }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
               <button 
-                onClick={() => onSelect(item.comparison)} 
+                onClick={() => onSelect(item.data)} 
                 style={{ flex: 1, marginRight: '5px', textAlign: 'left' }}>
                 {item.title || `Comparison ${index + 1}`}
               </button>
               <button 
                 onClick={() => onDelete(index)} 
                 style={{ background: 'red', color: 'white', border: 'none', padding: '5px' }}>
-                Delete
+                ✕
               </button>
             </div>
           </li>
@@ -28,7 +28,12 @@ const ComparisonHistorySidebar = ({ history, onDelete, onSelect }) => {
 };
 
 ComparisonHistorySidebar.propTypes = {
-  history: PropTypes.array.isRequired,
+  history: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      data: PropTypes.string.isRequired,
+    })
+  ).isRequired,
   onDelete: PropTypes.func.isRequired,
   onSelect: PropTypes.func.isRequired,
 };

--- a/src/components/ComparisonHistorySidebar.js
+++ b/src/components/ComparisonHistorySidebar.js
@@ -1,4 +1,4 @@
-import React from 'react';
+/* import React from 'react';
 import PropTypes from 'prop-types';
 
 const ComparisonHistorySidebar = ({ history, onDelete, onSelect }) => {
@@ -39,4 +39,85 @@ ComparisonHistorySidebar.propTypes = {
 };
 
 export default ComparisonHistorySidebar;
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Box, Button, Text } from '@mantine/core';
+import '../styles/ComparisonHistorySidebar.css';
+
+const ComparisonHistorySidebar = ({ history, onDelete, onSelect }) => {
+  return (
+    <div className="comparison-history-sidebar">
+      <Text weight={500} size="lg" mb="md" className="comparison-header">
+        Previous Comparisons
+      </Text>
+      <div className="comparison-list">
+        {history.map((item, index) => (
+          <Box key={index} className="comparison-item-box">
+             
+            {/* Display the comparison title */}
+            <Text
+              className="comparison-title"
+              onClick={() => onSelect(item.data)}
+            >
+              {item.title || `Comparison ${index + 1}`}
+            </Text>
+
+            {/* Display the URLs used for the comparison */}
+            {item.urls && (
+              <div className="comparison-urls">
+                {item.urls.url1 && (
+                  <div className="product-link">
+                    <a href={item.urls.url1} target="_blank" rel="noopener noreferrer">
+                      Product 1
+                    </a>
+                  </div>
+                )}
+                {item.urls.url2 && (
+                  <div className="product-link">
+                    <a href={item.urls.url2} target="_blank" rel="noopener noreferrer">
+                      Product 2
+                    </a>
+                  </div>
+                )}
+              </div>
+            )}
+            
+             {/* Delete button */}
+            <Button
+              color="red"
+              variant="filled"
+              onClick={() => onDelete(index)}
+              size="xs"
+              className="delete-button"
+            >
+              ✕
+            </Button>
+           
+          </Box>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+ComparisonHistorySidebar.propTypes = {
+  history: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      data: PropTypes.string.isRequired,
+      uurls: PropTypes.shape({
+        url1: PropTypes.string.isRequired,
+        url2: PropTypes.string.isRequired,
+      }).isRequired,
+    })
+  ).isRequired,
+  onDelete: PropTypes.func.isRequired,
+  onSelect: PropTypes.func.isRequired,
+};
+
+
+export default ComparisonHistorySidebar;
+
 

--- a/src/hooks/ComparisonHistoryManager.js
+++ b/src/hooks/ComparisonHistoryManager.js
@@ -1,0 +1,44 @@
+// hooks/useComparisonHistory.js
+import { useState, useEffect } from 'react';
+
+const ComparisonHistoryManager = () => {
+  // State for managing comparison history
+  const [history, setHistory] = useState([]);
+  const [selectedComparison, setSelectedComparison] = useState(null);
+
+  // Load history from localStorage on mount
+  useEffect(() => {
+    const savedComparisons = JSON.parse(localStorage.getItem('comparisonHistory')) || [];
+    setHistory(savedComparisons);
+  }, []);
+
+  // Function to save a comparison to history
+  const saveComparison = (comparisonData) => {
+    // Add URLs to the comparisonData object before saving it to history
+    const updatedComparisonData = {
+      title: comparisonData.title,
+      data: comparisonData.data,
+      urls: { ...comparisonData.urls }, // Add the URLs to be saved
+    };
+    const updatedHistory = [...history, updatedComparisonData];
+    setHistory(updatedHistory);
+    localStorage.setItem('comparisonHistory', JSON.stringify(updatedHistory));
+  };
+
+  // Function to delete a comparison from history
+  const deleteComparison = (index) => {
+    const updatedHistory = history.filter((_, idx) => idx !== index);
+    setHistory(updatedHistory);
+    localStorage.setItem('comparisonHistory', JSON.stringify(updatedHistory));
+  };
+
+  return {
+    history,
+    selectedComparison,
+    setSelectedComparison,
+    saveComparison,
+    deleteComparison,
+  };
+};
+
+export default ComparisonHistoryManager;

--- a/src/pages/Header.js
+++ b/src/pages/Header.js
@@ -10,7 +10,7 @@ export function Header() {
     <header className={classes.header}>
         <Container size='responsive' className={classes.inner}>
             <div className={classes.logo}><h1>Quibble</h1></div>
-            {/* <Burger lineSize={3} size='md' opened={opened} onClick={toggle}/> */}
+            <Burger lineSize={3} size='md' opened={opened} onClick={toggle} className={classes.burger} /> 
         </Container>
         
     </header>

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -88,7 +88,12 @@ const HomePage = ({ saveComparison, setSelectedComparison, selectedComparison })
   // Load selected comparison when a previous one is selected from the hamburger menu
   useEffect(() => {
     if (selectedComparison) {
-      setComparison(selectedComparison);
+      setStatus((prev) => ({
+        ...prev,
+        comparison: selectedComparison,
+        isProcessing: false,
+        error: '',
+      }));
     }
   }, [selectedComparison]);
 
@@ -187,13 +192,16 @@ const HomePage = ({ saveComparison, setSelectedComparison, selectedComparison })
 
   // Handle saving the current comparison
   const handleSaveComparison = () => {
-    const comparisonData = {
-      title: preferences.user_preference || `Comparison on ${new Date().toLocaleString()}`,
-      comparison,
-    };
-    saveComparison(comparisonData);
+    if(status.comparison){
+      const titleMatch = status.comparison.match(/^#\s*(.+)/m);
+      const title = titleMatch ? titleMatch[1].trim() : `Comparison on ${new Date().toLocaleString()}`;  
+    saveComparison({
+      title: title,
+      data: status.comparison // Use status.comparison to ensure you save the latest data.
+    });
+    }
   };
-
+  
   // Handle starting a new comparison by resetting the form
   const handleNewComparison = () => {
     resetForm();
@@ -203,7 +211,13 @@ const HomePage = ({ saveComparison, setSelectedComparison, selectedComparison })
   const resetForm = () => {
     setUrls(initialUrlsState);
     setPreferences(initialPreferencesState);
-    setComparison('');
+    setStatus({
+      isProcessing: false,
+      currentStep: '',
+      progressPercentage: 0,
+      error: '',
+      comparison: ''
+    });
     setError('');
   };
 

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -6,7 +6,7 @@ import ActionButton from '../components/ActionButton';
 import { Progress } from '@mantine/core';
 
 const HomePage = ({ saveComparison, setSelectedComparison, selectedComparison }) => {
-  const WEBSOCKET_URL = 'ws://localhost:8000/ws/compare';
+  const WEBSOCKET_URL = process.env.REACT_APP_WEBSOCKET_URL || 'ws://localhost:8000/ws/compare';
   const wsRef = useRef(null);
   
   const initialUrlsState = { url1: '', url2: '' };

--- a/src/pages/MainContainer.js
+++ b/src/pages/MainContainer.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import HomePage from './HomePage';
+import ComparisonHistorySidebar from '../components/ComparisonHistorySidebar';
+import ComparisonHistoryManager from '../hooks/ComparisonHistoryManager';
+import { Box } from '@mantine/core';
+
+const MainContainer = () => {
+  const {
+    history,
+    saveComparison,
+    deleteComparison,
+    selectedComparison,
+    setSelectedComparison
+  } = ComparisonHistoryManager();
+
+  return (
+    <Box className="main-container" style={{ display: 'flex', height: '100vh' }}>
+      {/* Main Content Area for Comparisons */}
+      <Box className="main-content" style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <HomePage
+          saveComparison={saveComparison}
+          setSelectedComparison={setSelectedComparison}
+          selectedComparison={selectedComparison}
+        />
+      </Box>
+
+      {/* Sidebar for Comparison History */}
+      <ComparisonHistorySidebar
+        history={history}
+        onDelete={deleteComparison}
+        onSelect={setSelectedComparison}
+      />
+    </Box>
+  );
+};
+
+export default MainContainer;

--- a/src/styles/ComparisonHistorySidebar.css
+++ b/src/styles/ComparisonHistorySidebar.css
@@ -1,0 +1,73 @@
+.comparison-history-sidebar {
+    width: 300px;
+    background: #f4f4f4;
+    padding: 10px;
+  }
+
+  .comparison-header {
+    text-align: center;          
+    font-weight: 500;           
+    font-size: 1.25rem;         
+    margin-bottom: 20px;         
+  }
+  
+  .comparison-item-box {
+    position: relative;
+    margin-bottom: 10px;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    background-color: #f9f9f9;
+  }
+  
+  .comparison-title {
+    cursor: pointer;
+    color: #007bff;
+    text-decoration: underline;
+    margin-top: 5px;
+    font-size: 0.875rem;
+  }
+  
+  .comparison-urls a {
+    color: #007bff;
+    text-decoration: none;
+  }
+  
+  .comparison-urls a:hover {
+    text-decoration: underline;
+  }
+
+  .comparison-urls .product-links-container {
+    display: flex;
+    align-items: center; 
+    gap: 5px; 
+  }
+  
+  .product-link {
+    margin: 0; 
+  }
+
+  .product-link a {
+    font-size: 0.875rem; 
+    color: #0073e6; 
+    text-decoration: none; 
+  }
+  
+  .product-link a:hover {
+    text-decoration: underline;
+  }
+  
+  
+  .delete-button {
+    position: absolute;  
+    bottom: 5px;           
+    right: 5px;         
+    background-color: #ff4d4f; 
+    color: white;
+    border: none;
+    cursor: pointer;
+    padding: 3px 6px;    
+    font-size: 0.75rem;  
+    border-radius: 3px;
+  }
+  

--- a/src/styles/HeaderMenu.module.css
+++ b/src/styles/HeaderMenu.module.css
@@ -7,6 +7,7 @@
 .inner {
   display: flex;
   justify-content: center; 
+  position: relative;
   align-items: center; 
   height: 100%;
 }
@@ -15,4 +16,12 @@
   text-align: center;
   font-size: var(--mantine-font-size-md);
   font-weight: bold;
+}
+
+
+.burger {
+  margin-left: auto; 
+  top: 10px; 
+  right: 20px;
+  cursor: pointer; 
 }


### PR DESCRIPTION
This PR enhances the functionality of saving and displaying comparison titles in the comparison history sidebar. The following updates have been made:

Title Extraction Improvement: The title is now correctly extracted from the comparison content using a more flexible regular expression.
Comparison History Sidebar Updates:
The sidebar now displays the proper comparison title.
Corrected the onSelect button logic to ensure the right comparison content (item.data) is loaded when selected.
Comparison content box updates:  New Comparison button is working now. 